### PR TITLE
Support for different OpenAI compatible endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ LABEL org.opencontainers.image.source="https://github.com/marknefedov/ollama-ope
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/ollama-proxy /ollama-proxy
 
-EXPOSE 8080
+EXPOSE 11434
 ENTRYPOINT ["/ollama-proxy"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  enchanted-ollama-proxy:
+    environment:
+      OPENAI_BASE_URL: "https://openrouter.ai/api/v1/"
+      OPENAI_API_KEY: "YOUR_KEY_HERE"
+    build: .
+    ports:
+      - "11434:11434"
+    restart: unless-stopped

--- a/main.go
+++ b/main.go
@@ -48,14 +48,24 @@ func main() {
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
 		if len(os.Args) > 1 {
-			apiKey = os.Args[1]
+			apiKey = os.Args[len(os.Args)-1]
 		} else {
 			slog.Error("OPENAI_API_KEY environment variable or command-line argument not set.")
 			return
 		}
 	}
 
-	provider := NewOpenrouterProvider(apiKey)
+	// Try to load the API key from environment variables or command-line arguments
+	baseUrl := os.Getenv("OPENAI_BASE_URL")
+	if baseUrl == "" {
+		if len(os.Args) > 2 {
+			baseUrl = os.Args[1]
+		} else {
+			baseUrl = "https://openrouter.ai/api/v1/"
+		}
+	}
+
+	provider := NewOpenrouterProvider(baseUrl, apiKey)
 
 	filter, err := loadModelFilter("models-filter")
 	if err != nil {
@@ -195,8 +205,8 @@ func main() {
 
 			// Create Ollama-compatible response
 			ollamaResponse := map[string]interface{}{
-				"model":             fullModelName,
-				"created_at":        time.Now().Format(time.RFC3339),
+				"model":      fullModelName,
+				"created_at": time.Now().Format(time.RFC3339),
 				"message": map[string]string{
 					"role":    "assistant",
 					"content": content,
@@ -309,8 +319,8 @@ func main() {
 
 		// ВАЖНО: Замените nil на 0 для числовых полей статистики
 		finalResponse := map[string]interface{}{
-			"model":             fullModelName,
-			"created_at":        time.Now().Format(time.RFC3339),
+			"model":      fullModelName,
+			"created_at": time.Now().Format(time.RFC3339),
 			"message": map[string]string{
 				"role":    "assistant",
 				"content": "", // Пустой контент для финального сообщения

--- a/provider.go
+++ b/provider.go
@@ -14,9 +14,9 @@ type OpenrouterProvider struct {
 	modelNames []string // Shared storage for model names
 }
 
-func NewOpenrouterProvider(apiKey string) *OpenrouterProvider {
+func NewOpenrouterProvider(baseUrl string, apiKey string) *OpenrouterProvider {
 	config := openai.DefaultConfig(apiKey)
-	config.BaseURL = "https://openrouter.ai/api/v1/" // Custom endpoint if needed
+	config.BaseURL = baseUrl
 	return &OpenrouterProvider{
 		client:     openai.NewClientWithConfig(config),
 		modelNames: []string{},

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,16 @@
 # Enchanted Proxy for OpenRouter
-This repository is specifically made for use with the [Enchanted project](https://github.com/gluonfield/enchanted/tree/main).
+This repository is specifically made for use with the [Enchanted project](https://github.com/gluonfield/enchanted/tree/main), but can also be used for several other purposes that require an Ollama Endpoint.
 The original author of this proxy is [marknefedov](https://github.com/marknefedov/ollama-openrouter-proxy).
 
 ## Description
-This repository provides a proxy server that emulates [Ollama's REST API](https://github.com/ollama/ollama) but forwards requests to [OpenRouter](https://openrouter.ai/). It uses the [sashabaranov/go-openai](https://github.com/sashabaranov/go-openai) library under the hood, with minimal code changes to keep the Ollama API calls the same. This allows you to use Ollama-compatible tooling and clients, but run your requests on OpenRouter-managed models.
+This repository provides a proxy server that emulates [Ollama's REST API](https://github.com/ollama/ollama) but forwards requests to [OpenRouter](https://openrouter.ai/), or any other [OpenAI compatible endpoint](https://platform.openai.com/docs/api-reference). It uses the [sashabaranov/go-openai](https://github.com/sashabaranov/go-openai) library under the hood, with minimal code changes to keep the Ollama API calls the same. This allows you to use Ollama-compatible tooling and clients, but run your requests on OpenRouter/OpenAI-managed models.
 Currently, it is enough for usage with [Jetbrains AI assistant](https://blog.jetbrains.com/ai/2024/11/jetbrains-ai-assistant-2024-3/#more-control-over-your-chat-experience-choose-between-gemini,-openai,-and-local-models). 
 
 ## Features
 - **Model Filtering**: You can provide a `models-filter` file in the same directory as the proxy. Each line in this file should contain a single model name. The proxy will only show models that match these entries. If the file doesn’t exist or is empty, no filtering is applied.
   
-  **Note**: OpenRouter model names may sometimes include a vendor prefix, for example `deepseek/deepseek-chat-v3-0324:free`. To make sure filtering works correctly, remove the vendor part when adding the name to your `models-filter` file, e.g. `deepseek-chat-v3-0324:free`.
-  
+  **Note**: OpenRouter model names may sometimes include a vendor prefix, for example `deepseek/deepseek-chat-v3-0324:free`. To make sure filtering works correctly, remove the vendor part when adding the name to your `models-filter` file, e.g. `deepseek-chat-v3-0324:free`.  
+- **OpenAI Endpoint**: The application can be configured to use any OpenAI compatible endpoint, to forward requests to.  
 - **Ollama-like API**: The server listens on `11434` and exposes endpoints similar to Ollama (e.g., `/api/chat`, `/api/tags`).
 - **Model Listing**: Fetch a list of available models from OpenRouter.
 - **Model Details**: Retrieve metadata about a specific model.
@@ -20,13 +20,20 @@ Currently, it is enough for usage with [Jetbrains AI assistant](https://blog.jet
 You can provide your **OpenRouter** (OpenAI-compatible) API key through an environment variable or a command-line argument:
 
 ### 1. Environment Variable
-
-    export OPENAI_API_KEY="your-openrouter-api-key"
+```bash
+    # export OPENAI_BASE_URL="https://some-open-ai-api/api/v1/" # Optional. Defaults to https://openrouter.ai/api/v1/
+    export OPENAI_API_KEY="your-api-key"
     ./ollama-proxy
+```
 
 ### 2. Command Line Argument
-
+```bash
     ./ollama-proxy "your-openrouter-api-key"
+```
+or
+```bash
+    ./ollama-proxy "https://some-open-ai-api/api/v1/" "your-api-key"
+```
 
 Once running, the proxy listens on port `11434`. You can make requests to `http://localhost:11434` with your Ollama-compatible tooling.
 


### PR DESCRIPTION
Hey!  

I added a new optional parameter to be able to specify the OpenAI-like endpoint that is used to forward requests to.  
This allows the tool to be used in more scenarios.  
For example: At work, we are not allowed to used public LLMs for certain projects and customers while developing. We are self hosting some LLMs. Using this tool, i can use Jetbrains AI with our self hosted LLMs.